### PR TITLE
feat (compatibility) make compatible with most recent version of Just…

### DIFF
--- a/Telerik.JustMock.Autofac.Tests/Telerik.JustMock.Autofac.Tests.csproj
+++ b/Telerik.JustMock.Autofac.Tests/Telerik.JustMock.Autofac.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Telerik.JustMock.Autofac.Tests</RootNamespace>
     <AssemblyName>Telerik.JustMock.Autofac.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -18,6 +18,7 @@
     <TestProjectType>UnitTest</TestProjectType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,7 +43,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="Telerik.JustMock">
-      <HintPath>..\packages\JustMock.2014.3.1204.3\lib\Net35\Telerik.JustMock.dll</HintPath>
+      <HintPath>..\packages\JustMock.2015.3.929.5\lib\Net35\Telerik.JustMock.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>

--- a/Telerik.JustMock.Autofac.Tests/packages.config
+++ b/Telerik.JustMock.Autofac.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net45" />
-  <package id="JustMock" version="2014.3.1204.3" targetFramework="net45" />
+  <package id="Autofac" version="3.5.2" targetFramework="net40" />
+  <package id="JustMock" version="2015.3.929.5" targetFramework="net40" />
 </packages>

--- a/Telerik.JustMock.Autofac.dll.nuspec
+++ b/Telerik.JustMock.Autofac.dll.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>JustMock.Autofac</id>
     <title>JustMock.Autofac</title>
-    <version>1.0.0</version>
+    <version>2.0.0</version>
     <authors>dragnev</authors>
     <owners>dragnev</owners>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0.html</licenseUrl>
@@ -14,13 +14,12 @@
     <copyright>Copyright 2015</copyright>
     <tags>justmock autofac</tags>
     <dependencies>
-      <dependency id="JustMock" version="2014.1.1424.1" />
+      <dependency id="JustMock" version="2015.3.929.5" />
 	  <dependency id="Autofac" version="3.5.2" />
     </dependencies>
   </metadata>
-
   <files>
-    <file src="Telerik.JustMock.Autofac\bin\Release\Telerik.JustMock.Autofac.dll" target="lib/Net45"/>
-    <file src="Telerik.JustMock.Autofac\bin\Release\Telerik.JustMock.Autofac.xml" target="lib/Net45"/>
+    <file src="Telerik.JustMock.Autofac\bin\Release\Telerik.JustMock.Autofac.dll" target="lib/Net40"/>
+    <file src="Telerik.JustMock.Autofac\bin\Release\Telerik.JustMock.Autofac.xml" target="lib/Net40"/>
   </files>
 </package>

--- a/Telerik.JustMock.Autofac.sln
+++ b/Telerik.JustMock.Autofac.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Telerik.JustMock.Autofac", "Telerik.JustMock.Autofac\Telerik.JustMock.Autofac.csproj", "{D5871B3C-15DD-4541-9B14-08056672856D}"
 EndProject

--- a/Telerik.JustMock.Autofac/Telerik.JustMock.Autofac.csproj
+++ b/Telerik.JustMock.Autofac/Telerik.JustMock.Autofac.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Telerik.JustMock.Autofac</RootNamespace>
     <AssemblyName>Telerik.JustMock.Autofac</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -40,7 +41,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Telerik.JustMock">
-      <HintPath>..\packages\JustMock.2014.3.1204.3\lib\Net35\Telerik.JustMock.dll</HintPath>
+      <HintPath>..\packages\JustMock.2015.3.929.5\lib\Net35\Telerik.JustMock.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Telerik.JustMock.Autofac/packages.config
+++ b/Telerik.JustMock.Autofac/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Autofac" version="3.5.2" targetFramework="net45" />
-  <package id="JustMock" version="2014.3.1204.3" targetFramework="net45" />
+  <package id="Autofac" version="3.5.2" targetFramework="net40" />
+  <package id="JustMock" version="2015.3.929.5" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This addresses the issue that I discovered and opened in issue #2.
1. Changed dependency on Telerik.JustMock from 2014.3.1204.3 to 2015.3.929.5
   (2015.3.929.5 is the earliest version published on Nuget.com that contains the API change compatible with the current edge release 2016.2.426.1)
2. Change assemblies to target .net Framework 4.0 to allow wider audience
3. Incremented Nuget package to 2.0. This is a breaking change that removes compatibility with older versions of Telerik.JustMock.
4. Added new Test Project Telerik.JustMock.Autofac.Tests.Edge. MSTest has a limitation of one AppDomain per Target Test Assembly, so I have this split to a separate assembly. (Could have created new AppDomains, but this felt less complex)
   This project tests compatibility of the library with the newest versions of the Telerik.JustMock library available on Nuget, but forcing an AssemblyBinding.
   It re-uses the tests defined in Telerik.JustMock.Autofac.Tests without copying the files by using a Link to the Source *.cs files.
   It adds a new test to ensure that the loaded version of Telerik.JustMock is the expected current version.
5. Added the same Assembly Version test to Telerik.JustMock.Autofac.Tests to make sure it's testing against the older version of Telerik.JustMock 2015.3.929.5.
